### PR TITLE
feat: add MCP tool annotations for read-only API operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ const getServer = () => {
       title: "Get Articles",
       description:
         "Get articles from dev.to. Can filter by username, tag, or other parameters.",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true
+      },
       inputSchema: {
         username: z.string().optional().describe("Filter articles by username"),
         tag: z.string().optional().describe("Filter articles by tag"),
@@ -66,6 +70,10 @@ const getServer = () => {
     {
       title: "Get Article",
       description: "Get a specific article by ID or path",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true
+      },
       inputSchema: {
         id: z.number().optional().describe("Article ID"),
         path: z
@@ -96,6 +104,10 @@ const getServer = () => {
     {
       title: "Get User",
       description: "Get user information by ID or username",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true
+      },
       inputSchema: {
         id: z.number().optional().describe("User ID"),
         username: z.string().optional().describe("Username"),
@@ -123,6 +135,10 @@ const getServer = () => {
     {
       title: "Get Tags",
       description: "Get popular tags from dev.to",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true
+      },
       inputSchema: {
         page: z
           .number()
@@ -154,6 +170,10 @@ const getServer = () => {
     {
       title: "Get Comments",
       description: "Get comments for a specific article",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true
+      },
       inputSchema: {
         article_id: z.number().describe("Article ID to get comments for"),
       },
@@ -176,6 +196,10 @@ const getServer = () => {
     {
       title: "Search Articles",
       description: "Search articles using query parameters",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true
+      },
       inputSchema: {
         q: z.string().describe("Search query"),
         page: z


### PR DESCRIPTION
This pull request adds `annotations` metadata to all the read-only endpoints in the `src/index.ts` server definition. These annotations provide hints that the endpoints are read-only and operate in an open-world context, which can help with documentation, tooling, or automated analysis.

This came about after [ChatGPT released their dev mode](https://platform.openai.com/docs/guides/developer-mode) and I noticed that my tools all said they could write, which they don't so I included [additional MCP tool annotations](https://modelcontextprotocol.io/legacy/concepts/tools#available-tool-annotations) to all the tools in the dev.to MCP server. Thanks @wasaga for this find.

**Before**

<img width="1320" height="1192" alt="CleanShot 2025-09-10 at 21 34 39@2x" src="https://github.com/user-attachments/assets/fc00905b-2f16-4fee-93c1-2d89d8a7e3c0" />

**After**

<img width="1320" height="1196" alt="CleanShot 2025-09-10 at 21 50 00@2x" src="https://github.com/user-attachments/assets/8b42b2e4-99e0-461c-a707-7a5e05341df1" />